### PR TITLE
add yolo_train_val_corrected and yolo_test_corrected DVC datasets

### DIFF
--- a/data/processed/.gitignore
+++ b/data/processed/.gitignore
@@ -10,3 +10,5 @@
 /sequential_test
 /yolo_toy
 /sequential_toy
+/yolo_train_val_corrected
+/yolo_test_corrected

--- a/data/processed/yolo_test_corrected.dvc
+++ b/data/processed/yolo_test_corrected.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: ba7cdca755a1bd332d4f8771d98e5322.dir
+  size: 269835006
+  nfiles: 5233
+  hash: md5
+  path: yolo_test_corrected

--- a/data/processed/yolo_train_val_corrected.dvc
+++ b/data/processed/yolo_train_val_corrected.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: 409302377938ce2a82f5338f3145cbbc.dir
+  size: 1914167911
+  nfiles: 32201
+  hash: md5
+  path: yolo_train_val_corrected


### PR DESCRIPTION
Corrected annotations from vision-rd/data-quality/frame-level/11_corrected_dataset. Tracked outside the pipeline via `dvc add` so the existing pipeline stays untouched. Importable from training repo with `dvc import --rev`.

- yolo_train_val_corrected: 14681 train / 1419 val images (smoke, nc=1)
- yolo_test_corrected: 2616 test images (smoke, nc=1)